### PR TITLE
Add argument print_model to control model display

### DIFF
--- a/model_ic.py
+++ b/model_ic.py
@@ -62,9 +62,12 @@ def validation(model, testloader, criterion, device):
     return test_loss, accuracy
 
 # Define NN function
-def make_NN(n_hidden, n_epoch, labelsdict, lr, device, model_name, trainloader, validloader, train_data):
+def make_NN(n_hidden, n_epoch, labelsdict, lr, device, model_name, trainloader, validloader, train_data, print_model):
     # Import pre-trained NN model 
     model = getattr(models, model_name)(pretrained=True)
+
+    if print_model:
+        print(model)
     
     # Freeze parameters that we don't need to re-train 
     for param in model.parameters():

--- a/train.py
+++ b/train.py
@@ -11,6 +11,7 @@ parser.add_argument("--hidden_units", type=int, default=1024, help="set hidden u
 parser.add_argument("--epochs", type=int, default=1, help="set epochs")
 parser.add_argument("--gpu", action="store_const", const="cuda", default="cpu", help="use gpu")
 parser.add_argument("--save_dir", help="save model")
+parser.add_argument("--print_model", default=False, help="print model")
 
 args = parser.parse_args()
 
@@ -19,7 +20,7 @@ cat_to_name = read_jason(args.category_names)
 trainloader, testloader, validloader, train_data = load_data(args.data_dir)
 
 model = make_NN(n_hidden=[args.hidden_units], n_epoch=args.epochs, labelsdict=cat_to_name, lr=args.learning_rate, device=args.gpu, \
-                model_name=args.arch, trainloader=trainloader, validloader=validloader, train_data=train_data)
+                model_name=args.arch, trainloader=trainloader, validloader=validloader, train_data=train_data, print_model=args.print_model)
 
 if args.save_dir:
     save_checkpoint(model, args.save_dir)


### PR DESCRIPTION
# Feature

Add flag to control whether to print the model or not. Defaults to `False`

# Nuances

If the flag is not specified, it defaults to a boolean value `False`. Otherwise, for any other value specified, the model will be printed. This is because the argument reads inputs as Strings even if something like `--print_model True` or `--print_model False` is passed.